### PR TITLE
Make export more robust and easier to diagnose

### DIFF
--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -86,7 +86,7 @@ class TotalExport(object):
     try:
       document = self.documents.open(file)
     except BaseException as ex:
-      self.ui.messageBox("Opening {} failed!".format(file.name))
+      self.ui.messageBox("Opening {} failed! {}".format(file.name, ex))
       return
 
     if document is None:

--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -129,7 +129,7 @@ class TotalExport(object):
       
       self._write_component(file_folder_path, design.rootComponent)
     except BaseException:
-      self.ui.messageBox("Failed while working on {}".format(file_folder_path))
+      self.ui.messageBox("Failed while working on {}\n{}".format(file_folder_path, traceback.format_exc()))
       raise
     finally:
       try:

--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -92,6 +92,8 @@ class TotalExport(object):
     if document is None:
       return
 
+    document.activate()
+
     try:
       file_folder = file.parentFolder
       file_folder_path = self._name(file_folder.name)

--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -214,7 +214,7 @@ class TotalExport(object):
     return out_path
   
   def _name(self, name):
-    return re.sub('[^a-zA-Z0-9 \n\.]', '', name)
+    return re.sub('[^a-zA-Z0-9 \n\.]', '', name).strip()
 
     
 

--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -16,6 +16,7 @@ class TotalExport(object):
     self.ui = self.app.userInterface
     self.data = self.app.data
     self.documents = self.app.documents
+    self.last_folder_path = "nothing yet..."
     
   def __enter__(self):
     return self
@@ -108,6 +109,8 @@ class TotalExport(object):
         file_folder_path,
         self._name(file.name) + "." + file.fileExtension
         )
+
+      self.last_folder_path = file_folder_path
 
       if not os.path.exists(file_folder_path):
         self.ui.messageBox("Couldn't make root folder {}".format(file_folder_path))
@@ -218,4 +221,4 @@ def run(context):
 
   except:
     ui  = app.userInterface
-    ui.messageBox('Failed:\n{}'.format(traceback.format_exc()))
+    ui.messageBox('Failed at {}:\n{}'.format(total_export.last_folder_path, traceback.format_exc()))

--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -130,7 +130,12 @@ class TotalExport(object):
       self.ui.messageBox("Failed while working on {}".format(file_folder_path))
       raise
     finally:
-      document.close(False)
+      try:
+        document.close(False)
+      except BaseException:
+        # self.ui.messageBox("Failed while closing {}\n{}".format(file_folder_path, traceback.format_exc()))
+        pass
+
 
   def _write_component(self, component_base_path, component: adsk.fusion.Component):
     design = component.parentDesign


### PR DESCRIPTION
For some reason my Fusion throws exceptions when closing documents which prevents any progress.

<img width="439" alt="Screenshot 2020-09-18 at 20 05 06" src="https://user-images.githubusercontent.com/478882/93663510-d973a900-fa68-11ea-91e7-31a504aba197.png">


Ignoring that particular exception solved the problem for me, I got a full export.

I also sneaked in a `document.activate()` so there is some visual feedback of progress.