### PR TITLE
Fixed a couple of issues a user ran into

### DIFF
--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -151,7 +151,8 @@ class TotalExport(object):
       self._write_component(sub_path, sub_component)
 
   def _write_step(self, output_path, component: adsk.fusion.Component):
-    if os.path.exists(output_path + ".stp"):
+    file_path = output_path + ".stp"
+    if os.path.exists(file_path):
       return
     export_manager = component.parentDesign.exportManager
 
@@ -159,7 +160,8 @@ class TotalExport(object):
     export_manager.execute(options)
 
   def _write_stl(self, output_path, component: adsk.fusion.Component):
-    if os.path.exists(output_path + ".stl"):
+    file_path = output_path + ".stl"
+    if os.path.exists(file_path):
       return
     export_manager = component.parentDesign.exportManager
 
@@ -184,23 +186,26 @@ class TotalExport(object):
         self._write_stl_body(os.path.join(output_path, body.name), body)
         
   def _write_stl_body(self, output_path, body):
-    if os.path.exists(output_path + ".stl"):
+    output_path + ".stl"
+    if os.path.exists(file_path):
       return
     export_manager = body.parentComponent.parentDesign.exportManager
 
     try:
-      options = export_manager.createSTLExportOptions(body, output_path)
+      options = export_manager.createSTLExportOptions(body, file_path)
       export_manager.execute(options)
     except BaseException:
       # Probably an empty model, ignore it
       pass
 
   def _write_iges(self, output_path, component: adsk.fusion.Component):
-    if os.path.exists(output_path + ".igs"):
+    file_path = output_path + ".igs"
+    if os.path.exists(file_path):
       return
+
     export_manager = component.parentDesign.exportManager
 
-    options = export_manager.createIGESExportOptions(output_path, component)
+    options = export_manager.createIGESExportOptions(file_path, component)
     export_manager.execute(options)
 
   def _write_dxf(self, output_path, sketch: adsk.fusion.Sketch):

--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -186,7 +186,7 @@ class TotalExport(object):
         self._write_stl_body(os.path.join(output_path, body.name), body)
         
   def _write_stl_body(self, output_path, body):
-    output_path + ".stl"
+    file_path = output_path + ".stl"
     if os.path.exists(file_path):
       return
     export_manager = body.parentComponent.parentDesign.exportManager

--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -217,7 +217,12 @@ class TotalExport(object):
     return out_path
   
   def _name(self, name):
-    return re.sub('[^a-zA-Z0-9 \n\.]', '', name)
+    name = re.sub('[^a-zA-Z0-9 \n\.]', '', name).strip()
+
+    if name.endswith('.stp') or name.endswith('.stl') or name.endswith('.igs'):
+      name = name[0: -4] + "_" + name[-3:]
+      
+    return name
 
     
 

--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -151,12 +151,16 @@ class TotalExport(object):
       self._write_component(sub_path, sub_component)
 
   def _write_step(self, output_path, component: adsk.fusion.Component):
+    if os.path.exists(output_path + ".stp"):
+      return
     export_manager = component.parentDesign.exportManager
 
     options = export_manager.createSTEPExportOptions(output_path, component)
     export_manager.execute(options)
 
   def _write_stl(self, output_path, component: adsk.fusion.Component):
+    if os.path.exists(output_path + ".stl"):
+      return
     export_manager = component.parentDesign.exportManager
 
     try:
@@ -180,6 +184,8 @@ class TotalExport(object):
         self._write_stl_body(os.path.join(output_path, body.name), body)
         
   def _write_stl_body(self, output_path, body):
+    if os.path.exists(output_path + ".stl"):
+      return
     export_manager = body.parentComponent.parentDesign.exportManager
 
     try:
@@ -190,6 +196,8 @@ class TotalExport(object):
       pass
 
   def _write_iges(self, output_path, component: adsk.fusion.Component):
+    if os.path.exists(output_path + ".igs"):
+      return
     export_manager = component.parentDesign.exportManager
 
     options = export_manager.createIGESExportOptions(output_path, component)

--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -221,7 +221,7 @@ class TotalExport(object):
 
     if name.endswith('.stp') or name.endswith('.stl') or name.endswith('.igs'):
       name = name[0: -4] + "_" + name[-3:]
-      
+
     return name
 
     


### PR DESCRIPTION
This fixes a couple of issues:

- Do not re-export existing files (It'll still open them)
- Strip leading and trailing spaces for path names
- Handle components ending with .stp, .stl, or .igs