### PR TITLE
Handle project descriptions ending in "."

### DIFF
--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -312,6 +312,8 @@ class TotalExport(object):
     if name.endswith('.stp') or name.endswith('.stl') or name.endswith('.igs'):
       name = name[0: -4] + "_" + name[-3:]
 
+    name = name.strip(".")
+
     return name
 
     


### PR DESCRIPTION
Projects with description ending in "." results in filenames ending in "." which is not legal on Windows