### PR TITLE
Handle application crash and allow multiple executions of the script (versioned backup)

### DIFF
--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -14,11 +14,11 @@ import os
 import re
 
 class ManageFailed:
-    def __init__(self, file_path, modified_time):
+    def __init__(self, file_path, modified_time, log):
       self.file_path = file_path
       self.modified_time = modified_time
       self.failed_path = file_path + ".failed"
-      self.log = Logger("Fusion 360 Total Export")
+      self.log = log
       self.failed = False
       self.failed_exists = False
 
@@ -201,7 +201,7 @@ class TotalExport(object):
         self.log.info("Model has not changed")
         return
 
-    with ManageFailed(f3_file, last_update_ts) as manager:
+    with ManageFailed(f3_file, last_update_ts, self.log) as manager:
       if not manager.failed_exists:
         try:
           document = self.documents.open(file)
@@ -268,7 +268,7 @@ class TotalExport(object):
   def _write_step(self, output_path, component: adsk.fusion.Component, modified_time):
     file_path = output_path + ".stp"
 
-    with ManageFailed(file_path, modified_time) as manager:
+    with ManageFailed(file_path, modified_time, self.log) as manager:
       if not manager.failed_exists:
         self.log.info("Writing step file \"{}\"".format(file_path))
         export_manager = component.parentDesign.exportManager
@@ -279,7 +279,7 @@ class TotalExport(object):
   def _write_stl(self, output_path, component: adsk.fusion.Component, modified_time):
     file_path = output_path + ".stl"
     try:
-      with ManageFailed(file_path, modified_time) as manager:
+      with ManageFailed(file_path, modified_time, self.log) as manager:
         if not manager.failed_exists:
           self.log.info("Writing stl file \"{}\"".format(file_path))
           export_manager = component.parentDesign.exportManager
@@ -308,7 +308,7 @@ class TotalExport(object):
     file_path = output_path + ".stl"
 
     try:
-      with ManageFailed(file_path, modified_time) as manager:
+      with ManageFailed(file_path, modified_time, self.log) as manager:
         if not manager.failed_exists:
           self.log.info("Writing stl body file \"{}\"".format(file_path))
           export_manager = body.parentComponent.parentDesign.exportManager
@@ -322,7 +322,7 @@ class TotalExport(object):
   def _write_iges(self, output_path, component: adsk.fusion.Component, modified_time):
     file_path = output_path + ".igs"
 
-    with ManageFailed(file_path, modified_time) as manager:
+    with ManageFailed(file_path, modified_time, self.log) as manager:
       if not manager.failed_exists:
         self.log.info("Writing iges file \"{}\"".format(file_path))
 
@@ -334,7 +334,7 @@ class TotalExport(object):
   def _write_dxf(self, output_path, sketch: adsk.fusion.Sketch, modified_time):
     file_path = output_path + ".dxf"
 
-    with ManageFailed(file_path, modified_time) as manager:
+    with ManageFailed(file_path, modified_time, self.log) as manager:
       if not manager.failed_exists:
         self.log.info("Writing dxf sketch file \"{}\"".format(file_path))
         sketch.saveAsDXF(file_path)

--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -14,23 +14,33 @@ import os
 import re
 
 class ManageFailed:
-    def __init__(self, file_path):
+    def __init__(self, file_path, modified_time):
+      self.file_path = file_path
+      self.modified_time = modified_time
       self.failed_path = file_path + ".failed"
       self.log = Logger("Fusion 360 Total Export")
+      self.failed = False
+      self.failed_exists = False
 
     def __enter__(self):
-      self.exists = os.path.exists(self.failed_path)
-      if self.exists:
+      self.failed_exists = os.path.exists(self.failed_path)
+      if self.failed_exists:
         self.log.info("Seems like a previous export failed. Fix the the problem and delete the file \"{}\"".format(self.failed_path))
       else:
         path = os.path.dirname(self.failed_path)
         Path(path).mkdir(parents=True, exist_ok=True)
         Path(self.failed_path).touch()
-      return self.exists
+      return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-      if exc_tb is None and not self.exists:
+      if self.failed_exists:
+        return
+      
+      if not self.failed and exc_tb is None:
         os.remove(self.failed_path)
+        # set the modified time to the last version created time
+        fileStat = os.stat(self.file_path)
+        os.utime(self.file_path, (fileStat.st_atime, self.modified_time))        
 
 class TotalExport(object):
   def __init__(self, app):
@@ -139,7 +149,8 @@ class TotalExport(object):
   def _get_files_for(self, folder):
     files = []
     for file in folder.dataFiles:
-      files.append(file)
+      if file.fileExtension == "f3d" or file.fileExtension != "f3z":
+        files.append(file)
 
     for sub_folder in folder.dataFolders:
       files.extend(self._get_files_for(sub_folder))
@@ -184,111 +195,97 @@ class TotalExport(object):
       existing_updated = os.path.getmtime(f3_file)
       if last_update_ts == existing_updated:
         self.log.info("Model has not changed")
-        pass
+        return
 
-    try:
-      document = self.documents.open(file)
+    with ManageFailed(f3_file, last_update_ts) as manager:
+      if not manager.failed_exists:
+        try:
+          document = self.documents.open(file)
 
-      if document is None:
-        raise Exception("Documents.open returned None")
+          if document is None:
+            raise Exception("Documents.open returned None")
 
-      document.activate()
-    except BaseException as ex:
-      self.num_issues += 1
-      self.log.exception("Opening {} failed!".format(file.name), exc_info=ex)
-      return
+          document.activate()
+        except BaseException as ex:
+          self.num_issues += 1
+          self.log.exception("Opening {} failed!".format(file.name), exc_info=ex)
+          manager.failed = True
+          return
 
-    try:
-      self.log.info("Writing to \"{}\"".format(file_folder_path))
+        try:
+          self.log.info("Writing to \"{}\"".format(file_folder_path))
 
-      fusion_document: adsk.fusion.FusionDocument = adsk.fusion.FusionDocument.cast(document)
-      design: adsk.fusion.Design = fusion_document.design
-      export_manager: adsk.fusion.ExportManager = design.exportManager
+          fusion_document: adsk.fusion.FusionDocument = adsk.fusion.FusionDocument.cast(document)
+          design: adsk.fusion.Design = fusion_document.design
+          export_manager: adsk.fusion.ExportManager = design.exportManager
 
-      with ManageFailed(f3_file) as failedExists:
-        if not failedExists:
           # Write f3d/f3z file
           options = export_manager.createFusionArchiveExportOptions(file_export_path)
           export_manager.execute(options)
 
-          # set the modified time to the last version created time
-          fileStat = os.stat(f3_file)
-          os.utime(f3_file, (fileStat.st_atime, last_update_ts))
-        else:
-          # don't bother with other export types when the main fail can't be downloaded
-          pass
-      
-      self._write_component(file_folder_path, design.rootComponent)
+          self._write_component(file_folder_path, design.rootComponent, last_update_ts)
 
-      self.log.info("Finished exporting file \"{}\"".format(file.name))
-    except BaseException as ex:
-      self.num_issues += 1
-      self.log.exception("Failed while working on \"{}\"".format(file.name), exc_info=ex)
-      raise
-    finally:
-      try:
-        if document is not None:
-          document.close(False)
-      except BaseException as ex:
-        self.num_issues += 1
-        self.log.exception("Failed to close \"{}\"".format(file.name), exc_info=ex)
+          self.log.info("Finished exporting file \"{}\"".format(file.name))
+        except BaseException as ex:
+          self.num_issues += 1
+          self.log.exception("Failed while working on \"{}\"".format(file.name), exc_info=ex)
+          raise
+        finally:
+          try:
+            if document is not None:
+              document.close(False)
+          except BaseException as ex:
+            self.num_issues += 1
+            self.log.exception("Failed to close \"{}\"".format(file.name), exc_info=ex)
 
 
-  def _write_component(self, component_base_path, component: adsk.fusion.Component):
+  def _write_component(self, component_base_path, component: adsk.fusion.Component, modified_time):
     self.log.info("Writing component \"{}\" to \"{}\"".format(component.name, component_base_path))
     design = component.parentDesign
     
     output_path = os.path.join(component_base_path, self._name(component.name))
 
-    self._write_step(output_path, component)
-    self._write_stl(output_path, component)
-    self._write_iges(output_path, component)
+    self._write_step(output_path, component, modified_time)
+    self._write_stl(output_path, component, modified_time)
+    self._write_iges(output_path, component, modified_time)
 
     sketches = component.sketches
     for sketch_index in range(sketches.count):
       sketch = sketches.item(sketch_index)
-      self._write_dxf(os.path.join(output_path, sketch.name), sketch)
+      self._write_dxf(os.path.join(output_path, sketch.name), sketch, modified_time)
 
     occurrences = component.occurrences
     for occurrence_index in range(occurrences.count):
       occurrence = occurrences.item(occurrence_index)
       sub_component = occurrence.component
       sub_path = self._take(component_base_path, self._name(component.name))
-      self._write_component(sub_path, sub_component)
+      self._write_component(sub_path, sub_component, modified_time)
 
-  def _write_step(self, output_path, component: adsk.fusion.Component):
+  def _write_step(self, output_path, component: adsk.fusion.Component, modified_time):
     file_path = output_path + ".stp"
-    if os.path.exists(file_path):
-      self.log.info("Step file \"{}\" already exists".format(file_path))
-      return
-  
-    with ManageFailed(file_path) as failedExists:
-      if not failedExists:
+
+    with ManageFailed(file_path, modified_time) as manager:
+      if not manager.failed_exists:
         self.log.info("Writing step file \"{}\"".format(file_path))
         export_manager = component.parentDesign.exportManager
 
         options = export_manager.createSTEPExportOptions(output_path, component)
         export_manager.execute(options)
 
-  def _write_stl(self, output_path, component: adsk.fusion.Component):
+  def _write_stl(self, output_path, component: adsk.fusion.Component, modified_time):
     file_path = output_path + ".stl"
-    if os.path.exists(file_path):
-      self.log.info("Stl file \"{}\" already exists".format(file_path))
-      return
-
-    with ManageFailed(file_path) as failedExists:
-      if not failedExists:
-        self.log.info("Writing stl file \"{}\"".format(file_path))
-        export_manager = component.parentDesign.exportManager
-
-        try:
+    try:
+      with ManageFailed(file_path, modified_time) as manager:
+        if not manager.failed_exists:
+          self.log.info("Writing stl file \"{}\"".format(file_path))
+          export_manager = component.parentDesign.exportManager
           options = export_manager.createSTLExportOptions(component, output_path)
           export_manager.execute(options)
-        except BaseException as ex:
-          self.log.exception("Failed writing stl file \"{}\"".format(file_path), exc_info=ex)
+    except BaseException as ex:
+      self.log.exception("Failed writing stl file \"{}\"".format(file_path), exc_info=ex)
 
-          if component.occurrences.count + component.bRepBodies.count + component.meshBodies.count > 0:
-            self.num_issues += 1
+      if component.occurrences.count + component.bRepBodies.count + component.meshBodies.count > 0:
+        self.num_issues += 1
 
     bRepBodies = component.bRepBodies
     meshBodies = component.meshBodies
@@ -297,38 +294,32 @@ class TotalExport(object):
       self._take(output_path)
       for index in range(bRepBodies.count):
         body = bRepBodies.item(index)
-        self._write_stl_body(os.path.join(output_path, body.name), body)
+        self._write_stl_body(os.path.join(output_path, body.name), body, modified_time)
 
       for index in range(meshBodies.count):
         body = meshBodies.item(index)
-        self._write_stl_body(os.path.join(output_path, body.name), body)
+        self._write_stl_body(os.path.join(output_path, body.name), body, modified_time)
         
-  def _write_stl_body(self, output_path, body):
+  def _write_stl_body(self, output_path, body, modified_time):
     file_path = output_path + ".stl"
-    if os.path.exists(file_path):
-      self.log.info("Stl body file \"{}\" already exists".format(file_path))
-      return
 
-    with ManageFailed(file_path) as failedExists:
-      if not failedExists:
-        self.log.info("Writing stl body file \"{}\"".format(file_path))
-        export_manager = body.parentComponent.parentDesign.exportManager
+    try:
+      with ManageFailed(file_path, modified_time) as manager:
+        if not manager.failed_exists:
+          self.log.info("Writing stl body file \"{}\"".format(file_path))
+          export_manager = body.parentComponent.parentDesign.exportManager
 
-        try:
           options = export_manager.createSTLExportOptions(body, file_path)
           export_manager.execute(options)
-        except BaseException:
-          # Probably an empty model, ignore it
-          pass
+    except BaseException:
+      # Probably an empty model, ignore it
+      pass
 
-  def _write_iges(self, output_path, component: adsk.fusion.Component):
+  def _write_iges(self, output_path, component: adsk.fusion.Component, modified_time):
     file_path = output_path + ".igs"
-    if os.path.exists(file_path):
-      self.log.info("Iges file \"{}\" already exists".format(file_path))
-      return
 
-    with ManageFailed(file_path) as failedExists:
-      if not failedExists:
+    with ManageFailed(file_path, modified_time) as manager:
+      if not manager.failed_exists:
         self.log.info("Writing iges file \"{}\"".format(file_path))
 
         export_manager = component.parentDesign.exportManager
@@ -336,14 +327,11 @@ class TotalExport(object):
         options = export_manager.createIGESExportOptions(file_path, component)
         export_manager.execute(options)
 
-  def _write_dxf(self, output_path, sketch: adsk.fusion.Sketch):
+  def _write_dxf(self, output_path, sketch: adsk.fusion.Sketch, modified_time):
     file_path = output_path + ".dxf"
-    if os.path.exists(file_path):
-      self.log.info("DXF sketch file \"{}\" already exists".format(file_path))
-      return
 
-    with ManageFailed(file_path) as failedExists:
-      if not failedExists:
+    with ManageFailed(file_path, modified_time) as manager:
+      if not manager.failed_exists:
         self.log.info("Writing dxf sketch file \"{}\"".format(file_path))
         sketch.saveAsDXF(file_path)
 

--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -35,6 +35,10 @@ class ManageFailed:
     def __exit__(self, exc_type, exc_val, exc_tb):
       if self.failed_exists:
         return
+
+      # file was not created
+      if not os.path.exists(self.file_path):
+        return
       
       if not self.failed and exc_tb is None:
         os.remove(self.failed_path)

--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -261,9 +261,13 @@ class TotalExport(object):
     occurrences = component.occurrences
     for occurrence_index in range(occurrences.count):
       occurrence = occurrences.item(occurrence_index)
-      sub_component = occurrence.component
-      sub_path = self._take(component_base_path, self._name(component.name))
-      self._write_component(sub_path, sub_component, modified_time)
+      try:
+        sub_component = occurrence.component
+        sub_path = self._take(component_base_path, self._name(component.name))
+        self._write_component(sub_path, sub_component, modified_time)
+      except BaseException as ex:
+        self.log.exception("Failed to get component", exc_info=ex)
+
 
   def _write_step(self, output_path, component: adsk.fusion.Component, modified_time):
     file_path = output_path + ".stp"

--- a/README.md
+++ b/README.md
@@ -14,13 +14,20 @@ Need to export all of your fusion data in a bunch of formats? We've got you cove
 ## Why did you make this?
 Autodesk just announced that they were limiting features in their free tier to a level that made people a wee bit upset. I pay for Fusion 360, but I get that it's too much of an expense for some people. I had experience with exporting STL files for BotQueue (shhh spoilers) and figured that if I wrote a plugin, no one would have to do manual exports. Yay! Automation reigns supreme!
 
+### Extended feature
+Use this script to backup all your projects and models as `f3d` file. Running the script again will only export the models which have been modified (validates the date), and all other files will be exported with the version number added to the file name (stl, step, ...).
+
 ## What happens if I don't like what this plugin does?
-No warrenty is implied, etc. etc. Go blame Autodesk for changing the free tier. If you want to blame me for anything, blame me and my sense of ethics for feeling like I need to write this program in the first place.
+No warranty is implied, etc. etc. Go blame Autodesk for changing the free tier. If you want to blame me for anything, blame me and my sense of ethics for feeling like I need to write this program in the first place.
 
 ## What if I find a bug?
 If an exception occurs, the script will let you know after it has exported everything that it can export. There will be a log file called output.log in your export folder. Submit an issue with that file attached. Please and thank you!
 
 Also, if you can share the file that it failed on, that may help me, but it depends on what the exception actually shows.
+
+### Failed exports
+When an export fails a file is left with the ending `.failed`. The output file can provide details about the error.
+You can search for the `.failed` files and manually try to export the desired output or resolve the error.
 
 ## I don't like your style of writing
 That wasn't a question. But yeah... me too some days.


### PR DESCRIPTION
When I ran the script Fusion360 crashed. I wanted to make sure I can run the script again and skip the failed model.
In order to do so, I create now a `.failed` file before hand and delete it after the model has been exported. This way, the file remains if the application crashes or an error occurs. In second run the model is skipped in case the `.failed` file exists. Deleting the file and running the script again, tries to export the model again but skip all other existing if the date doesn't match.

In addition, I always wanted to have a way, to backup all my models as f3d file locally. I now apply the model version creation date to the exported f3d file and all other exports. This allows me to skip the file if the version (date) matches before even opening the file in Fusion360.
For backup of course using the Forge API would probably be a more elegant and faster solution.

Both changes allows me to run the script multiple times and only export changed or fixed models.

The downside currently is that all other exports contains the model version number. Which makes it complicated to use e.g. git as a local versioning for those files. I didn't spend time to investigate on that.

There is no beauty in my code since I'm not that familiar with python. Maybe you are also interested in those changes and want to benefit or take out some stuff.