### PR TITLE
Added hub selection dialog

### DIFF
--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -63,18 +63,21 @@ class TotalExport(object):
 
   def _export_data(self, output_path):
     progress_dialog = self.ui.createProgressDialog()
-    progress_dialog.show("Exporting data!", "", 0, 1, 1)
-
     all_hubs = self.data.dataHubs
     for hub_index in range(all_hubs.count):
 
       hub = all_hubs.item(hub_index)
 
-      export_this_hub = self.ui.messageBox("Export Hub \"{}\"?".format(hub.name), "Shall this Hub be exported?", YesNoButtonType, QuestionIconType)
+      #export_this_hub = self.ui.messageBox("Export Hub \"{}\"?".format(hub.name), "Shall this Hub be exported?", adsk.core.YesNoButtonType, adsk.core.QuestionIconType)
+      export_this_hub = self.ui.messageBox("Export hub \"{}\"?".format(hub.name), "Shall this hub be exported?", 3, 1)
 
-      if(export_this_hub == DialogNo)
-        hub_index = hub_index + 1
+      #if export_this_hub == adsk.core.DialogNo:
+      if export_this_hub == 3:
+        self.log.info("Skipping hub \"{}\" due to user request!".format(hub.name))
         continue
+
+      # progress_dialog has to be created and shown here, or otherwise no interaction with the hub selection dialog is possible.
+      progress_dialog.show("Exporting data!", "", 0, 1, 1)
 
       self.log.info("Exporting hub \"{}\"".format(hub.name))
 
@@ -112,6 +115,7 @@ class TotalExport(object):
           self._write_data_file(output_path, file)
         self.log.info("Finished exporting project \"{}\"".format(project.name))
       self.log.info("Finished exporting hub \"{}\"".format(hub.name))
+      progress_dialog.hide() # Closing the progress bar dialog for the current hub to gain focus back to the hub selection dialog
 
     self.ui.messageBox("No more Hubs to export from!", "Finished")
 

--- a/Fusion 360 Total Export.py
+++ b/Fusion 360 Total Export.py
@@ -67,7 +67,14 @@ class TotalExport(object):
 
     all_hubs = self.data.dataHubs
     for hub_index in range(all_hubs.count):
+
       hub = all_hubs.item(hub_index)
+
+      export_this_hub = self.ui.messageBox("Export Hub \"{}\"?".format(hub.name), "Shall this Hub be exported?", YesNoButtonType, QuestionIconType)
+
+      if(export_this_hub == DialogNo)
+        hub_index = hub_index + 1
+        continue
 
       self.log.info("Exporting hub \"{}\"".format(hub.name))
 
@@ -105,6 +112,8 @@ class TotalExport(object):
           self._write_data_file(output_path, file)
         self.log.info("Finished exporting project \"{}\"".format(project.name))
       self.log.info("Finished exporting hub \"{}\"".format(hub.name))
+
+    self.ui.messageBox("No more Hubs to export from!", "Finished")
 
   def _ask_for_output_path(self):
     folder_dialog = self.ui.createFolderDialog()


### PR DESCRIPTION
As I mentioned in my feature request here https://github.com/Jnesselr/fusion-360-total-exporter/issues/30
I wanted the ability to select the hubs that I am exporting.

My change adds a question dialog for each hub, asking the user if the hub shall be exported or not.

- If not, the For-loop continues with the next hub.
- If yes, the current hub is exported.

A better solution would be to be able to select all hubs beforehand, but I could not figure out the proper dialog method.
This way, an unattended export could be realized. But I think it is better to have the option to skip hubs (like company hubs, e.g.) than to export everything. And, as Fusion 360 tends to crash if the main loop is occupied for too long, it is always good to check for the current status, anyway.

Moreover, the progress dialog has to be shown after the hub selection dialog as otherwise, no interaction is possible with the selection dialog. Therefore, the progress dialog has to be hidden after the current hub's export loop.

Best wishes,
Martin